### PR TITLE
Fix bug with isInitialFetch

### DIFF
--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -12,11 +12,11 @@ function useFetch(initialRequest, onSuccess, onError) {
         setFetching: setFetching,
         onSuccess: onSuccess,
         onError: onError,
+        onFinish: useCallback(() => setCount((count) => count + 1), []),
     });
 
     const refresh = useCallback(() => {
         setRequest((request) => Object.assign({}, request));
-        setCount((count) => count + 1);
     }, []);
 
     return {

--- a/src/hooks/useRequest.js
+++ b/src/hooks/useRequest.js
@@ -5,7 +5,8 @@ function useRequest(request, {
     setErrorMessage,
     setFetching,
     onSuccess,
-    onError
+    onError,
+    onFinish,
 }) {
     useEffect(() => {
         if (request === null) return;
@@ -26,11 +27,12 @@ function useRequest(request, {
                     if (setErrorMessage) setErrorMessage(err.message);
                     if (onError) await onError();
             }
+            if (onFinish) await onFinish();
             if (setFetching) setFetching(false);
         }
         doFetch();
         return () => {abortController.abort();}
-    }, [request, setErrorMessage, setFetching, onSuccess, onError])
+    }, [request, setErrorMessage, setFetching, onSuccess, onError, onFinish])
 }
 
 export default useRequest;


### PR DESCRIPTION
This PR fixes a small bug with `useFetch:isInitialFetch`. As of now, the request counter is increased immediately after the request is handled, instead of when a new request is induced. Otherwise, there were a few milliseconds / one renders in which the `useFetch:isInitialFetch` was falsely `true`.